### PR TITLE
Fix language recognized by GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.css linguist-vendored
 *.bib linguist-documentation
+manuscript/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.css linguist-vendored
+*.bib linguist-documentation


### PR DESCRIPTION
Hi @smwindecker :wave: !
I've noticed that this package is misidentified by GitHub's [linguist](https://github.com/github/linguist) as mostly being composed of .tex and .css. So I've followed the [recommendations](https://github.com/github/linguist#overrides) to only consider .R files so it is tagged as an R repository.
Hope it helps! 